### PR TITLE
fix: pull request description building

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -188,14 +188,17 @@ func Codemods(targets []Target) error {
 }
 
 func buildDescription(target *Target) string {
-	descriptions := make([]string, len(target.Codemods))
+	builder := strings.Builder{}
 
-	for _, codemod := range target.Codemods {
-		descriptions = append(descriptions, codemod.Description)
+	builder.WriteString("Applied the following codemods:\n\n")
+
+	for i, codemod := range target.Codemods {
+		builder.WriteString(fmt.Sprintf("λ %s", codemod.Description))
+
+		if i < len(target.Codemods)-1 {
+			builder.WriteString("\n\n")
+		}
 	}
 
-	return fmt.Sprintf(
-		"Applied the following codemods: %s",
-		strings.Join(descriptions, "\n\nλ "),
-	)
+	return builder.String()
 }

--- a/src/apply/apply_test.go
+++ b/src/apply/apply_test.go
@@ -1,0 +1,37 @@
+package apply
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_buildDescription(t *testing.T) {
+	t.Parallel()
+
+	target := Target{
+		Repo: Repository{
+			AccessToken: "access_token",
+			URL:         "https://github.com/PoorlyDefinedBehaviour/apply_codemod_test",
+			Branch:      "main",
+		},
+		Codemods: []Codemod{
+			{Description: "a"},
+			{Description: "b"},
+			{Description: "c"},
+		},
+	}
+
+	expected :=
+		`Applied the following codemods:
+
+λ a
+
+λ b
+
+λ c`
+
+	actual := buildDescription(&target)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Here's how it looks now:

![image](https://user-images.githubusercontent.com/17282221/136676095-be450dba-fae0-411e-afd7-4dd5be19ca2f.png)



closes: https://github.com/PoorlyDefinedBehaviour/apply_codemod/issues/8