### PR TITLE
feat: convenience method to access package name

### DIFF
--- a/src/codemod/codemod.go
+++ b/src/codemod/codemod.go
@@ -37,7 +37,10 @@ func New(sourceCode []byte) *SourceFile {
 }
 
 func NormalizeString(s string) string {
-	return strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\t", "")
+	return s
 }
 
 func insertAfter(node NodeWithParent, newNode ast.Node) {

--- a/src/codemod/codemod_test.go
+++ b/src/codemod/codemod_test.go
@@ -1,14 +1,17 @@
 package codemod_test
 
 import (
+	"apply_codemod/src/codemod"
 	"fmt"
 	"go/ast"
 	"strings"
 	"testing"
-
-	"apply_codemod/src/codemod"
 	"github.com/stretchr/testify/assert"
 )
+
+func equals(a, b string) bool {
+	return codemod.NormalizeString(a) == codemod.NormalizeString(b)
+}
 
 func Test_Map(t *testing.T) {
 	t.Parallel()
@@ -1234,7 +1237,7 @@ func main() {
 
 	actual := string(file.SourceCode())
 
-	assert.Equal(t, codemod.NormalizeString(expected), codemod.NormalizeString(actual))
+	assert.True(t, equals(expected, actual))
 }
 
 func Test_IfStmt_InsertAfter(t *testing.T) {
@@ -1271,7 +1274,7 @@ func main() {
 
 	actual := string(file.SourceCode())
 
-	assert.Equal(t, expected, actual)
+	assert.True(t, equals(expected, actual))
 }
 
 func Test_Package(t *testing.T) {


### PR DESCRIPTION
Adds `codemod.SourceFile.Package()` which returns a struct containing a pointer to the package name identifier