### PR TITLE
refactor(codemod): add Package helper methods

### DIFF
--- a/src/codemod/codemod.go
+++ b/src/codemod/codemod.go
@@ -208,6 +208,14 @@ type Package struct {
 	Identifier *ast.Ident
 }
 
+func (pkg *Package) Name() string {
+	return pkg.Identifier.Name
+}
+
+func (pkg *Package) SetName(name string) {
+	pkg.Identifier.Name = name
+}
+
 func (code *SourceFile) Package() Package {
 	return Package{Identifier: code.file.Name}
 }

--- a/src/codemod/codemod_test.go
+++ b/src/codemod/codemod_test.go
@@ -1286,22 +1286,24 @@ func Test_Package(t *testing.T) {
 	func main() {}
 `)
 
-	t.Run("returns struct representing the package", func(t *testing.T) {
-		t.Parallel()
-
-		file := codemod.New(sourceCode)
-
-		assert.Equal(t, "main", file.Package().Identifier.Name)
-	})
-
-	t.Run("renames package", func(t *testing.T) {
+	t.Run("returns package name", func(t *testing.T) {
 		t.Parallel()
 
 		file := codemod.New(sourceCode)
 
 		pkg := file.Package()
 
-		pkg.Identifier.Name = "newpackagename"
+		assert.Equal(t, "main", pkg.Name())
+	})
+
+	t.Run("modifies package name", func(t *testing.T) {
+		t.Parallel()
+
+		file := codemod.New(sourceCode)
+
+		pkg := file.Package()
+
+		pkg.SetName("newpackagename")
 
 		expected :=
 			`package newpackagename


### PR DESCRIPTION
Adds two helper methods to `codemod.Package`:

Take this package for example:

```go
package foo

func f() {}
```

`Name` - returns the package name
```go
pkg := file.Package()

pkg.Name() // "foo"
```

`SetName()` - modifies the package name
```go
pkg := file.Package()

pkg.SetName("bar")

pkg.Name() // "bar"
```