### PR TITLE
feat: add SourceFile.TraverseAst

### DIFF
--- a/src/codemod/codemod.go
+++ b/src/codemod/codemod.go
@@ -204,6 +204,27 @@ func getCallExprLiteral(cursor *ast.CallExpr) string {
 	return fmt.Sprintf("%s.%s", identifier.Name, selector.Sel.Name)
 }
 
+func (code *SourceFile) TraverseAst(f func(NodeWithParent)) {
+	parent := NodeWithParent{
+		Node: code.file,
+	}
+
+	ast.Inspect(
+		code.file,
+		func(node ast.Node) bool {
+			p := parent
+			parent = NodeWithParent{
+				Parent: &p,
+				Node:   node,
+			}
+
+			f(parent)
+
+			return true
+		},
+	)
+}
+
 type Package struct {
 	Identifier *ast.Ident
 }

--- a/src/codemod/codemod_test.go
+++ b/src/codemod/codemod_test.go
@@ -1,12 +1,11 @@
 package codemod_test
 
 import (
+	"apply_codemod/src/codemod"
 	"fmt"
 	"go/ast"
 	"strings"
 	"testing"
-
-	"apply_codemod/src/codemod"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1476,4 +1475,24 @@ func main() {}
 
 		assert.Equal(t, expected, string(file.SourceCode()))
 	})
+}
+
+func Test_TraverseAst(t *testing.T) {
+	t.Parallel()
+
+	found := false
+
+	file := codemod.New([]byte(`
+		package bar 
+
+		func z() {}
+	`))
+
+	file.TraverseAst(func(node codemod.NodeWithParent) {
+		if fun, ok := node.Node.(*ast.FuncDecl); ok {
+			found = fun.Name.Name == "z"
+		}
+	})
+
+	assert.True(t, found)
 }


### PR DESCRIPTION
If the user needs to do something we don't support, they can use `SourceFile.TraverseAst(f)`:

```go
file := codemod.New([]byte(`
  package bar 

  func z() {}
`))

file.TraverseAst(func(node codemod.NodeWithParent) {
  if fun, ok := node.Node.(*ast.FuncDecl); ok {
    ...
  }
})
```

closes: https://github.com/PoorlyDefinedBehaviour/apply_codemod/issues/23