### PR TITLE
feat(codemod): add Add and Remove to Imports

### DIFF
--- a/src/codemod/codemod.go
+++ b/src/codemod/codemod.go
@@ -249,6 +249,16 @@ func (imports *Imports) Paths() []string {
 	return out
 }
 
+func (imports *Imports) Contains(importPath string) bool {
+	for _, path := range imports.Paths() {
+		if path == importPath {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (imports *Imports) Add(importPath string) {
 	for _, path := range imports.Paths() {
 		if path == importPath {
@@ -262,6 +272,20 @@ func (imports *Imports) Add(importPath string) {
 			Value: Quote(importPath),
 		},
 	})
+}
+
+func (imports *Imports) Remove(importPath string) {
+	specs := make([]ast.Spec, 0)
+
+	for _, spec := range *imports.specs {
+		if Unquote(spec.(*ast.ImportSpec).Path.Value) == importPath {
+			continue
+		}
+
+		specs = append(specs, spec)
+	}
+
+	*imports.specs = specs
 }
 
 func (code *SourceFile) Imports() *Imports {

--- a/src/codemod/codemod_test.go
+++ b/src/codemod/codemod_test.go
@@ -1,11 +1,12 @@
 package codemod_test
 
 import (
-	"apply_codemod/src/codemod"
 	"fmt"
 	"go/ast"
 	"strings"
 	"testing"
+
+	"apply_codemod/src/codemod"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1555,15 +1556,13 @@ func Test_SourceFile_Imports(t *testing.T) {
 		assert.False(t, imports.Contains("package_c"))
 	})
 
-	t.Run("removing imports", func(t *testing.T) {
-		t.Run("removes import path from file imports", func(t *testing.T) {
-			file := codemod.New(codemod.NewInput{SourceCode: sourceCode})
+	t.Run("removes import path from file imports", func(t *testing.T) {
+		file := codemod.New(codemod.NewInput{SourceCode: sourceCode})
 
-			imports := file.Imports()
+		imports := file.Imports()
 
-			imports.Remove("package_a")
+		imports.Remove("package_a")
 
-			assert.Equal(t, []string{"errors", "package_b"}, imports.Paths())
-		})
+		assert.Equal(t, []string{"errors", "package_b"}, imports.Paths())
 	})
 }

--- a/src/codemod/codemod_test.go
+++ b/src/codemod/codemod_test.go
@@ -1543,4 +1543,27 @@ func Test_SourceFile_Imports(t *testing.T) {
 
 		assert.Equal(t, []string{"errors", "package_a", "package_b", "new_import"}, imports.Paths())
 	})
+
+	t.Run("checks if file contains import path", func(t *testing.T) {
+		file := codemod.New(codemod.NewInput{SourceCode: sourceCode})
+
+		imports := file.Imports()
+
+		assert.True(t, imports.Contains("errors"))
+		assert.True(t, imports.Contains("package_a"))
+		assert.True(t, imports.Contains("package_b"))
+		assert.False(t, imports.Contains("package_c"))
+	})
+
+	t.Run("removing imports", func(t *testing.T) {
+		t.Run("removes import path from file imports", func(t *testing.T) {
+			file := codemod.New(codemod.NewInput{SourceCode: sourceCode})
+
+			imports := file.Imports()
+
+			imports.Remove("package_a")
+
+			assert.Equal(t, []string{"errors", "package_b"}, imports.Paths())
+		})
+	})
 }


### PR DESCRIPTION
Adds two methods to `codemod.Imports`.

`Contains(string) bool` - returns true when file contains import path.

```go
file := codemod.New(codemod.NewInput{SourceCode: []byte(`
  package foo

  import "a"

  func F(){}
`)})

file.Imports().Contains("a") // true
file.Imports().Contains("other_import") // false
```

`Remove(string)` - removes import path from file imports

```go
file := codemod.New(codemod.NewInput{SourceCode: []byte(`
  package foo

  import "a"

  func F(){}
`)})

file.Imports().Contains("a") // true
file.Imports().Remove("a")
file.Imports().Contains("a") // false
```

closes: 39