### PR TITLE
fix(apply): skip repositories without changes

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -212,7 +212,7 @@ func Codemods(targets []Target) error {
 		}
 		if len(filesAffected) == 0 {
 			fmt.Printf("%s %s\n", color.RedString("[NOT CHANGED]"), target.Repo.URL)
-			return nil
+			continue
 		}
 
 		err = repo.Commit(


### PR DESCRIPTION
When we found a repository that had no changes after the codemod was applied to it, we were not applying the codemods to the other repositories if there were any.

From now on, if a repository has no changes after the codemod was applied to it, we just skip the repository.

closes: #84